### PR TITLE
[0.6.0] SW-127 특별 미션 CRUD

### DIFF
--- a/src/main/java/com/github/kmu_shell_we/domain/mission/_season_mission/controller/AdminSeasonMissionController.java
+++ b/src/main/java/com/github/kmu_shell_we/domain/mission/_season_mission/controller/AdminSeasonMissionController.java
@@ -32,6 +32,15 @@ public class AdminSeasonMissionController {
         return ApiResponse.ok(adminSeasonMissionService.getSeasonMissions(season));
     }
 
+    @GetMapping("/special")
+    @Operation(summary = "특정 시즌 스페셜 미션 조회")
+    public ApiResponse<MissionListResponse> getSeasonSpecialMissions(
+            @Parameter(description = "시즌 ID", schema = @Schema(type = "string", format = "uuid")) @PathVariable Season season
+    ) {
+
+        return ApiResponse.ok(adminSeasonMissionService.getSeasonSpecialMissions(season));
+    }
+
     @PostMapping("/{mission}")
     @Operation(summary = "시즌 미션 생성")
     public ApiResponse<MissionResponse> createSeasonMission(

--- a/src/main/java/com/github/kmu_shell_we/domain/mission/_season_mission/service/AdminSeasonMissionService.java
+++ b/src/main/java/com/github/kmu_shell_we/domain/mission/_season_mission/service/AdminSeasonMissionService.java
@@ -3,6 +3,7 @@ package com.github.kmu_shell_we.domain.mission._season_mission.service;
 import com.github.kmu_shell_we.domain.mission._season_mission.entity.SeasonMission;
 import com.github.kmu_shell_we.domain.mission._season_mission.exception.SeasonMissionExceptions;
 import com.github.kmu_shell_we.domain.mission._season_mission.repository.SeasonMissionRepository;
+import com.github.kmu_shell_we.domain.mission.constant.MissionType;
 import com.github.kmu_shell_we.domain.mission.dto.response.MissionListResponse;
 import com.github.kmu_shell_we.domain.mission.dto.response.MissionResponse;
 import com.github.kmu_shell_we.domain.mission.entity.Mission;
@@ -21,6 +22,14 @@ public class AdminSeasonMissionService {
     public MissionListResponse getSeasonMissions(Season season) {
 
         return MissionListResponse.fromSeasonMission(seasonMissionRepository.findAllBySeason(season));
+    }
+
+    @Transactional(readOnly = true)
+    public MissionListResponse getSeasonSpecialMissions(Season season){
+
+        return MissionListResponse.fromSeasonMission(
+                seasonMissionRepository.findAllBySeasonAndMissionType(season, MissionType.SPECIAL)
+        );
     }
 
     @Transactional


### PR DESCRIPTION
## 📋 변경사항 요약

관리자가 특별 미션 목록을 보고 선택하기 위한 특정 시즌 특별 미션 목록 조회


<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [ ] 변경사항이 기존 테스트를 통과합니다
- [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 관리자용 시즌 스페셜 미션 조회 API를 추가했습니다: GET /admin/seasons/{season}/missions/special
  * 시즌 ID를 기준으로 해당 시즌의 스페셜 미션 목록을 조회할 수 있습니다.
  * 기존 시즌 미션 조회와 동일한 응답 구조를 사용해 일관성을 유지합니다.
  * API 문서화가 적용되어 콘솔/스웨거에서 바로 확인하고 테스트할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->