### PR TITLE
[0.6.0] SW-124 아이템 뽑기 전 포인트 잔량 확인하기

### DIFF
--- a/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/exception/ItemExceptions.java
+++ b/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/exception/ItemExceptions.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum ItemExceptions implements ApiExceptionCode {
 
     FAILED_TO_DRAW("ITEM_001", "아이템을 뽑는데 실패했습니다."),
-    NOT_ENOUGH_POINT("ITEM_001", "포인트가 부족합니다."),
+    NOT_ENOUGH_POINT("ITEM_002", "포인트가 부족합니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/exception/ItemExceptions.java
+++ b/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/exception/ItemExceptions.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum ItemExceptions implements ApiExceptionCode {
 
     FAILED_TO_DRAW("ITEM_001", "아이템을 뽑는데 실패했습니다."),
+    NOT_ENOUGH_POINT("ITEM_001", "포인트가 부족합니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/service/ItemService.java
+++ b/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/service/ItemService.java
@@ -11,6 +11,7 @@ import com.github.kmu_shell_we.domain.season._team._item.dto.response.detail.Exp
 import com.github.kmu_shell_we.domain.season._team._item.dto.response.detail.MissionChangeResponse;
 import com.github.kmu_shell_we.domain.season._team._item.dto.response.detail.ScoreDeductionResponse;
 import com.github.kmu_shell_we.domain.season._team._item.entity.Item;
+import com.github.kmu_shell_we.domain.season._team._item.exception.ItemExceptions;
 import com.github.kmu_shell_we.domain.season._team._item.repository.ItemRepository;
 import com.github.kmu_shell_we.domain.season._team._team_mission.entity.TeamMission;
 import com.github.kmu_shell_we.domain.season._team._team_mission.exceptions.TeamMissionExceptions;
@@ -49,6 +50,14 @@ public class ItemService {
     @Transactional
     @PreAuthorize("@itemService.canAccessItem(#user, #season, #team)")
     public ItemResponse drawItem(User user, Season season, Team team) {
+
+        // 0. 포인트 조회 및 차감
+        if (team.getPoint() < 100) {
+
+            throw ItemExceptions.NOT_ENOUGH_POINT.toException();
+        }
+
+        team.setPoint(team.getPoint() - 100);
 
         // 1. 아이템 랜덤 뽑기
         ItemType itemType = drawRandomItem();


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [ ] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [ ] 변경사항이 기존 테스트를 통과합니다
- [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 아이템 뽑기에는 이제 최소 100포인트가 필요합니다. 조건을 충족하지 못하면 뽑기가 진행되지 않으며 ‘포인트가 부족합니다’라는 안내가 표시됩니다.
  * 뽑기 성공 시 자동으로 100포인트가 차감되어 잔여 포인트가 즉시 반영됩니다.
  * 포인트가 부족한 경우 충전 또는 획득 후 다시 시도할 수 있어, 사용자가 비용과 결과를 명확히 인지할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->