### PR TITLE
[0.6.0] SW-122 경험치 두배 아이템 획득 시 DB에 저장

### DIFF
--- a/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/entity/Item.java
+++ b/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/entity/Item.java
@@ -22,4 +22,7 @@ public class Item extends BaseSchema {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     ItemType type;
+
+    @Column(nullable = false)
+    boolean isUnUsed = false;
 }

--- a/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/service/ItemService.java
+++ b/src/main/java/com/github/kmu_shell_we/domain/season/_team/_item/service/ItemService.java
@@ -63,19 +63,25 @@ public class ItemService {
         ItemType itemType = drawRandomItem();
 
         // 2. 뽑은 아이템을 DB에 저장
-        itemRepository.save(Item.builder()
-                .team(team)
-                .type(itemType)
-                .build());
+        if (itemType == ItemType.EXPERIENCE_DOUBLE) {
+
+            itemRepository.save(Item.builder()
+                    .team(team)
+                    .type(itemType)
+                    .isUnUsed(true)
+                    .build());
+        } else {
+
+            itemRepository.save(Item.builder()
+                    .team(team)
+                    .type(itemType)
+                    .build());
+        }
 
         // 3. 뽑은 아이템에 대한 응답 DTO 반환
         return switch (itemType) {
             case BOOM -> BoomResponse.of();
-            case EXPERIENCE_DOUBLE -> {
-
-                // TODO: 미션 성공 시 경험치 두 배가 되도록
-                yield ExperienceDoubleResponse.of();
-            }
+            case EXPERIENCE_DOUBLE -> ExperienceDoubleResponse.of();
             case MISSION_CHANGE -> {
 
                 TeamMission current = teamMissionRepository

--- a/src/main/java/com/github/kmu_shell_we/domain/season/_team/_team_mission/_submission/service/SubmissionService.java
+++ b/src/main/java/com/github/kmu_shell_we/domain/season/_team/_team_mission/_submission/service/SubmissionService.java
@@ -1,5 +1,7 @@
 package com.github.kmu_shell_we.domain.season._team._team_mission._submission.service;
 
+import com.github.kmu_shell_we.domain.season._team._item.constant.ItemType;
+import com.github.kmu_shell_we.domain.season._team._item.entity.Item;
 import com.github.kmu_shell_we.domain.season._team._team_mission._submission.dto.request.CreateSubmissionRequest;
 import com.github.kmu_shell_we.domain.season._team._team_mission._submission.dto.response.SubmissionListResponse;
 import com.github.kmu_shell_we.domain.season._team._team_mission._submission.dto.response.SubmissionResponse;
@@ -62,7 +64,27 @@ public class SubmissionService {
                         .build()
         );
 
+        reward(team, teamMission);
+
         return SubmissionResponse.from(submission);
+    }
+
+    public void reward(Team team, TeamMission teamMission) {
+
+        Integer reward = teamMission.getMission().getReward();
+
+        team.setExperience(team.getExperience() + reward);
+        team.setPoint(team.getPoint() + reward / 2);
+
+        // 경험치 두 배 아이템 존재 여부 확인 및 존재 시 경험치 한 번 더 지급
+        team.getItems().stream()
+                .filter(Item::isUnUsed)
+                .filter(item -> item.getType().equals(ItemType.EXPERIENCE_DOUBLE))
+                .findFirst()
+                .ifPresent(item -> {
+                    item.setUnUsed(false);
+                    team.setExperience(team.getExperience() + reward);
+                });
     }
 
     public boolean canAccessSubmission(User user, Season season, Team team) {


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [X] 새로운 기능 추가
- [X] 기존 기능 개선
- [X] 버그 수정
- [X] 리팩토링
- [ ] 문서 업데이트
- [X] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [X] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [X] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [X] 변경사항이 기존 테스트를 통과합니다
- [ ] 새로운 테스트를 추가했습니다 (해당하는 경우)

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 미션 제출 후 보상 흐름이 추가되어 팀 경험치와 포인트가 자동 반영됩니다.
  - 팀이 보유한 미사용 “경험치 2배” 아이템이 있으면 한 번에 한해 자동으로 소모되어 추가 경험치를 획득합니다.
  - “경험치 2배” 아이템은 획득 시 미사용 상태로 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->